### PR TITLE
#686 include low-scoring features

### DIFF
--- a/src/lib/why/sz-why-entities.component.ts
+++ b/src/lib/why/sz-why-entities.component.ts
@@ -233,8 +233,8 @@ export class SzWhyEntitiesComparisonComponent extends SzWhyReportBaseComponent i
                         if(_scoreDetails.nameScoringDetails.surnameScore)     { _nameScoreValues.push(`sur:${_scoreDetails.nameScoringDetails.surnameScore}`);}
                         if(_scoreDetails.nameScoringDetails.generationScore)  { _nameScoreValues.push(`gen:${_scoreDetails.nameScoringDetails.generationScore}`);}
                         _retVal += (_nameScoreValues.length > 0 ? ` (${_nameScoreValues.join('|')})` : '');
-                    } else if(_scoreDetails && _scoreDetails.score) {
-                        _retVal += `(full:${_scoreDetails.score})`;
+                    } else if(_scoreDetails && _scoreDetails.score > -1) {
+                        _retVal += ` (${_scoreDetails.score})`;
                     }
                     if(['SAME','CLOSE','PLAUSIBLE'].indexOf(_scoreDetails.scoringBucket) > -1) {
                         _retVal += '</div>\n';
@@ -242,7 +242,19 @@ export class SzWhyEntitiesComparisonComponent extends SzWhyReportBaseComponent i
                     _retVal += '</div>\n';
                 } else {
                     valueAdded = featureValue;
-                    _retVal += '<div class="ws-nowrap line-text">'+ featureValue +'</div>\n';
+                    _retVal += '<div class="ws-nowrap line-text">'+ featureValue;
+                    if(_scoreDetails && _scoreDetails.nameScoringDetails) {
+                        let _nameScoreValues  = [];
+                        if(_scoreDetails.nameScoringDetails.fullNameScore)    { _nameScoreValues.push(`full:${_scoreDetails.nameScoringDetails.fullNameScore}`);}
+                        if(_scoreDetails.nameScoringDetails.orgNameScore)     { _nameScoreValues.push(`org:${_scoreDetails.nameScoringDetails.orgNameScore}`);}
+                        if(_scoreDetails.nameScoringDetails.givenNameScore)   { _nameScoreValues.push(`giv:${_scoreDetails.nameScoringDetails.givenNameScore}`);}
+                        if(_scoreDetails.nameScoringDetails.surnameScore)     { _nameScoreValues.push(`sur:${_scoreDetails.nameScoringDetails.surnameScore}`);}
+                        if(_scoreDetails.nameScoringDetails.generationScore)  { _nameScoreValues.push(`gen:${_scoreDetails.nameScoringDetails.generationScore}`);}
+                        _retVal += (_nameScoreValues.length > 0 ? ` (${_nameScoreValues.join('|')})` : '');
+                    } else if(_scoreDetails && _scoreDetails.score > -1) {
+                        _retVal += ' ('+ _scoreDetails.score +')';
+                    }
+                    _retVal += '</div>\n';
                 }
             }
             return [_retVal, valueAdded];
@@ -398,7 +410,7 @@ export class SzWhyEntitiesComparisonComponent extends SzWhyReportBaseComponent i
                                         if(_res[0] && !_retVal || _retVal === undefined) _retVal = '';
                                         if(_res[0]) _retVal += _res[0];
                                     });
-                                }else if(_feat.featureDetails && _feat.featureDetails.forEach){
+                                } else if(_feat.featureDetails && _feat.featureDetails.forEach){
                                     _feat.featureDetails.forEach((fd)=>{
                                         let _res = addFeatureToResult(fd, _scoreDetails, _feat.featureDetails, mk, fieldName, valuesAlreadyAdded);
                                         if(_res[1]) valuesAlreadyAdded.push(_res[1]);

--- a/src/lib/why/sz-why-report-base.component.ts
+++ b/src/lib/why/sz-why-report-base.component.ts
@@ -294,20 +294,24 @@ export class SzWhyReportBaseComponent implements OnInit, OnDestroy {
                 if(_a.candidateFeature && ((_a.inboundFeature && _a.inboundFeature.featureId !== _a.candidateFeature.featureId) || !_a.inboundFeature)) {
                   retVal += `${_a.candidateFeature.featureValue}`;
                 }
-                if(_a.score){
-                  retVal += ` (full: ${_a.score})`;
+                if(_a.score > -1){
+                  retVal += ` (${_a.score})`;
                   if(_a.inboundFeature && _a.candidateFeature && _a.inboundFeature.featureId !== _a.candidateFeature.featureId) {
                     retVal += '</div>'+le;
                   }
                 }
                 retVal += '</div>';
               } else if((a as SzEntityFeature) && (a as SzEntityFeature).primaryValue) {
-                // no scoring available
-                let f = (a as SzEntityFeature);
+                // no scoring available ?
+                let f   = (a as SzEntityFeature);
+                let _a  = (a as SzFeatureScore);
                 retVal += '<div class="line-text ws-nowrap">'+ f.primaryValue;
                 let stats = fBId && fBId.has(f.primaryId) ? fBId.get(f.primaryId).statistics : false;
                 if(stats && stats.entityCount) {
                   retVal += ` [${stats.entityCount}]`;
+                }
+                if(_a.score > -1 && _a.scoringBucket){
+                  retVal += ` (${_a.scoringBucket.toLowerCase()}: ${_a.score})`;
                 }
                 retVal += '</div>'+le;
               } else if((a as SzNonScoringRecordFeature).featureType === 'NS') {
@@ -376,6 +380,7 @@ export class SzWhyReportBaseComponent implements OnInit, OnDestroy {
           if(data && data.forEach){
             data.forEach((_feature, i) => {
               let le = (i < data.length-1) ? '\n': '';
+              let isScoringFeature = (_feature as SzFeatureScore) && (_feature as SzFeatureScore).score > -1
               if((_feature as SzEntityFeature).primaryValue) {
                 // this is a entity feature, make sure we're not duplicating values
                 let f = (_feature as SzEntityFeature);
@@ -383,6 +388,9 @@ export class SzWhyReportBaseComponent implements OnInit, OnDestroy {
                 retVal += f.primaryValue;
                 if(stats && stats.entityCount) {
                   retVal += ` [${stats.entityCount}]`;
+                }
+                if(isScoringFeature){
+                  retVal += ` (${(_feature as SzFeatureScore).score})`;
                 }
                 retVal += le;
               } else if((_feature as SzFeatureScore).candidateFeature) {
@@ -395,6 +403,9 @@ export class SzWhyReportBaseComponent implements OnInit, OnDestroy {
                 if(stats && stats.entityCount) {
                   retVal += ` [${stats.entityCount}]`;
                 }
+                if(isScoringFeature){
+                  retVal += ` (${f.score})`;
+                }
                 retVal += '</span></div>'+le;
               } else if((_feature as SzCandidateKey).featureType) {
                 // candidate key
@@ -404,6 +415,9 @@ export class SzWhyReportBaseComponent implements OnInit, OnDestroy {
                 retVal += f.featureValue;
                 if(stats && stats.entityCount) {
                   retVal += ` [${stats.entityCount}]`;
+                }
+                if(isScoringFeature){
+                  retVal += ` (${(_feature as SzFeatureScore).score})`;
                 }
                 retVal += '</div>'+ le;
               } else if(_feature) {


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #686 

## Why was change needed

currently not all features in the why/why not screen display scores if they're in the match key. Often, especially in the case of Why Not we want to display low-ranking scores even if they are not in the match key because they inform the user what may be contributing to the non-matching behavior, or why two results may have not resolved.


