### PR TITLE
#690 #689 graph node coloring changes

### DIFF
--- a/src/lib/common/utils.ts
+++ b/src/lib/common/utils.ts
@@ -225,6 +225,30 @@ export function isValueTypeOfArray(value: any) {
   return retVal;
 }
 
+/** are all values in one array present in the comparison array with no extra members 
+ * present in either.
+*/
+export function areArrayMembersEqual(value1: any[], value2: any[]) {
+  let _tempArr1ValsMap    = new Map( (value1 as unknown as string[]).map((val) => { return [val.toString(), val]; }));
+  let _tempAllValsMap     = new Map(_tempArr1ValsMap);
+  // add existing entityId's to hashmap
+  if(value2 && value2.forEach) {
+    value2.forEach((value) => {
+      _tempAllValsMap.set(value as string, value);
+    });
+    // now remove all entity id's that are identical to the values in input values
+    // if there is a remaining value then the id sets are different
+    if((value1 as unknown as string[]) && (value1 as unknown as string[]).forEach) {
+      (value1 as unknown as string[]).forEach((valStr) => {
+        if(_tempAllValsMap.has(valStr.toString())) { _tempAllValsMap.delete(valStr.toString()); }
+      });
+    }
+    
+  }
+  let noRemainder   = _tempAllValsMap.size <= 0;
+  return noRemainder;
+}
+
 export function interpolateTemplate(template, args)  {
   return Object.entries(args).reduce(
       (result, [arg, val]) => result.replace(`$\{${arg}}`, `${val}`),

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -163,7 +163,6 @@
           Active/Focused Enitity
           <span #ttt6 class="tooltip-text">The color of the current entity or entities</span>
         </span>
-        <small class="note-sub">(*note overrides datasource member color if selected)</small>
       </label>
     </li>
   </ul>

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -206,7 +206,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
         // assume it's already cast correctly
         this._matchKeyTokenSelectionScope = (value as SzMatchKeyTokenFilterScope);
     }
-    console.log(`@senzing/sdk-components-ng/sz-graph-filter.matchKeyTokenSelectionScope(${value} | ${(this._matchKeyTokenSelectionScope as unknown as string)})`, this._matchKeyTokenSelectionScope);
+    //console.log(`@senzing/sdk-components-ng/sz-graph-filter.matchKeyTokenSelectionScope(${value} | ${(this._matchKeyTokenSelectionScope as unknown as string)})`, this._matchKeyTokenSelectionScope);
   }
   /**
    * get the value of match key token filterings scope. possible values are 
@@ -225,7 +225,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   private _showCoreMatchKeyTokenChips: boolean       = false;
   @Input() public set showCoreMatchKeyTokenChips(value: boolean) {
     this._showCoreMatchKeyTokenChips = value;
-    console.log(`@senzing/sdk-components-ng/sz-graph-filter.showCoreMatchKeyTokenChips(${value})`, this._showCoreMatchKeyTokenChips);
+    //console.log(`@senzing/sdk-components-ng/sz-graph-filter.showCoreMatchKeyTokenChips(${value})`, this._showCoreMatchKeyTokenChips);
   }
   public get showCoreMatchKeyTokenChips(): boolean {
     return this._showCoreMatchKeyTokenChips;
@@ -582,19 +582,36 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   }
   /** handler for when a color value for a source in the "colorsByDataSourcesForm" has changed */
   onDsColorChange(dsValue: string, src?: any, evt?) {
+    // first check if color is 000 or fff
+    // if so this is a remove not an update
+    let _isRemoveOp = false;
+    //console.log(`changed color for "${dsValue}" to "${src.value}"`);
+    if(['#ffffff','#000000'].includes(src.value)) {
+      _isRemoveOp = true;
+    }
     // update color value in array
     if(this._dataSources) {
       let _dsIndex = this._dataSources.findIndex((dsVal: SzDataSourceComposite) => {
         return dsVal.name === dsValue;
       });
       if(_dsIndex && this._dataSources && this._dataSources[ _dsIndex ]) {
-        this._dataSources[ _dsIndex ].color = src.value;
+        if(_isRemoveOp) {
+          this._dataSources[ _dsIndex ].color = undefined;
+          //delete this._dataSources[ _dsIndex ].color;
+        } else {
+          this._dataSources[ _dsIndex ].color = src.value;
+        }
       }
     }
     // update color swatch bg color(for prettier boxes)
     if(src && src.style && src.style.setProperty){
-      src.style.setProperty('background-color', src.value);
+      if(_isRemoveOp) {
+        src.style.removeProperty('background-color');
+      } else {
+        src.style.setProperty('background-color', src.value);
+      }
     }
+
     // update colors pref
     if( this.prefs && this.prefs.graph) {
       // there is some sort of mem reference clone issue

--- a/src/lib/scss/graph.scss
+++ b/src/lib/scss/graph.scss
@@ -130,6 +130,12 @@ body {
       fill: var(--sz-graph-node-icon-color);
     }
 
+    &.sz-graph-primary-node {
+      .sz-graph-icon-enclosure {
+        fill: var(--sz-graph-primary-entity-color);
+      }
+    }
+
     &.graph-node-rel-primary {
       .sz-graph-node-icon-colored {
         fill: var(--sz-graph-node-icon-color);

--- a/src/lib/services/sz-css-class.service.ts
+++ b/src/lib/services/sz-css-class.service.ts
@@ -65,7 +65,7 @@ export class SzCSSClassService {
     this.headElement.appendChild(cssEle);
     return cssEle.sheet as CSSStyleSheet;
   }
-  /** dynamicall set/create a css class and it's values */
+  /** dynamically set/create a css class and it's values */
   public setStyle(selectorText: string, styleName: string, value: string): void {
     let rules: CSSRuleList = this.styleSheet.cssRules.length > 0 || this.styleSheet.rules.length == 0 ? this.styleSheet.cssRules : this.styleSheet.rules;
     let ruleIndex: number  = Array.from(rules).findIndex(r => r instanceof CSSStyleRule && r.selectorText.toLowerCase() == selectorText.toLowerCase());
@@ -78,8 +78,25 @@ export class SzCSSClassService {
       let newRuleIndex = this.styleSheet.insertRule(selectorText + `{ ${styleName}: ${value}}`, rules.length);
       return; 
     } else {
-      this.styleSheet.deleteRule(ruleIndex);
+      if(ruleIndex >= 0) { 
+        this.styleSheet.deleteRule(ruleIndex);
+      }
       this.styleSheet.insertRule(selectorText + `{ ${styleName}: ${value}}`, rules.length);
+    }
+  }
+  /** dynamically remove a css class by selector and  */
+  public removeStyle(selectorText: string, styleName?: string) {
+    if(!this.styleSheet){ return; }
+    let rules: CSSRuleList = this.styleSheet.cssRules.length > 0 || this.styleSheet.rules.length == 0 ? this.styleSheet.cssRules : this.styleSheet.rules;
+    let ruleIndex: number  = Array.from(rules).findIndex(r => r instanceof CSSStyleRule && r.selectorText.toLowerCase() == selectorText.toLowerCase());
+    if(ruleIndex >= 0){ 
+      //try{
+        if(!styleName) {
+          this.styleSheet.deleteRule(ruleIndex);
+        } else {
+          (this.styleSheet.cssRules[ruleIndex] as CSSStyleRule).style.removeProperty(styleName);
+        }
+      //} catch(err) {}
     }
   }
   /** dynamically set a css variable on the body element */


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #689
resolves #690

## Why was change needed

When selecting datasource colors if the primary node color is chosen and the primary node is part of that datasource the color displayed is the color chosen for the primary and not the datasource member color.

Additionally a critical bug was found while working on this issue that causes an infinite re-render loop. This PR includes the fix for that issue as well( #689 )
 
## What does change improve

Changing this behavior will allow the primary focused node's color to be changed to the color of it's datasource if a color has been chosen. Additionally there is a new behavior to UNSET the chosen color be selecting either pure white(#ffffff) or pure black(#000000) in the color picker. Being able to unset a chosen color for a datasource that the primary node is a member off will return it's color to the color selected for focused/primary nodes.
